### PR TITLE
delete single author

### DIFF
--- a/server/controllers/authorsController.js
+++ b/server/controllers/authorsController.js
@@ -66,6 +66,29 @@ class AuthorsController {
         });
       });
   }
+
+  static delete(req, res) {
+    const { author_id } = req.params;
+    dbConfig.query(`DELETE FROM book_library.authors WHERE author_id = ${author_id}`)
+      .then((author) => {
+        if (author.rowCount) {
+          res.status(200).json({
+            message: 'Author deleted',
+          });
+        } else {
+          res.status(404).json({
+            status: 'error',
+            message: 'Author not found',
+          });
+        }
+      })
+      .catch((err) => {
+        res.status(400).json({
+          status: 'error',
+          message: err.message,
+        });
+      });
+  }
 }
 
 export default AuthorsController;

--- a/server/routes/authorsRoute.js
+++ b/server/routes/authorsRoute.js
@@ -5,5 +5,6 @@ const authorsRouter = Router();
 authorsRouter.post('/authors', AuthorsController.addNew)
 authorsRouter.get('/authors', AuthorsController.getAllAuthors);
 authorsRouter.get('/authors/:author_id', AuthorsController.getOne);
+authorsRouter.delete('/authors/:author_id', AuthorsController.delete);
 
 export default authorsRouter;


### PR DESCRIPTION
ensure author can be deleted from the database

add delete request logic
add HTTP delete verb to serve delete requests

can be manually tested using postman, make a delete request to 
`http://localhost:5001/api/v1/authors/author_id`

[Delivers [ft-feature-endpoint-author-delete](https://trello.com/c/4N0JNnAu/14-delete-an-author-from-the-database)]