### PR TITLE
ft(feature):get a category

### DIFF
--- a/server/controllers/categoriesController.js
+++ b/server/controllers/categoriesController.js
@@ -17,6 +17,30 @@ class CategoriesController {
         });
       });
   }
+
+  static getOne(req, res) {
+    const { category_id } = req.params;
+    dbConfig.query(`SELECT * FROM book_library.categories WHERE category_id = ${category_id}`)
+      .then((category) => {
+        if (category.rowCount > 0) {
+          res.status(200).json({
+            status: 'Category found',
+            data: category.rows,
+          });
+        } else {
+          res.status(404).json({
+            status: 'error',
+            message: 'Category not found',
+          });
+        }
+      })
+      .catch((err) => {
+        res.status(400).json({
+          status: 'error',
+          message: err.message,
+        });
+      });
+  }
 }
 
 export default CategoriesController;

--- a/server/routes/categoriesRoute.js
+++ b/server/routes/categoriesRoute.js
@@ -4,5 +4,6 @@ import CategoriesController from '../controllers/categoriesController';
 const categoriesRouter = Router();
 
 categoriesRouter.get('/categories', CategoriesController.getAll);
+categoriesRouter.get('/categories/:category_id', CategoriesController.getOne);
 
 export default categoriesRouter;


### PR DESCRIPTION
ensure one cateagory can be fetched
ensure GET method can be used to fetch a single category

add the logic to handle how a single category should be obtained
add the GET method to handle requests

can be tested manually to using postman, send a get request to 
`http://localhost:5001/api/v1/categories/category_id`

[Delivers [ft-feature-endpoint-categories-getOne](https://trello.com/c/3jjca12A/23-get-a-single-category#)]