### PR TITLE
add new category to the database

### DIFF
--- a/server/controllers/categoriesController.js
+++ b/server/controllers/categoriesController.js
@@ -41,6 +41,43 @@ class CategoriesController {
         });
       });
   }
+
+  static addNew(req, res) {
+    const { category_name } = req.body;
+    if (!category_name) {
+      return res.status(400).json({
+        message: 'Missing fields not allowed',
+      });
+    }
+    const newCategory = category_name;
+    dbConfig.query('INSERT INTO book_library.categories (category_name) VALUES ($1) RETURNING *', [category_name])
+      .then((category) => {
+        if (category.rowCount > 0) {
+          res.status(200).json({
+            message: 'Category added',
+            data: category.rows,
+          });
+        } else {
+          res.status(400).json({
+            status: 'error',
+            message: 'new category could not be added',
+          });
+        }
+      })
+      .catch((err) => {
+        if (err.message.includes('unique')) {
+          res.status(400).json({
+            status: 'error',
+            message: 'category already exists in the database',
+          });
+        } else {
+          res.status(400).json({
+            status: 'error',
+            message: err.message,
+          });
+        }
+      });
+  }
 }
 
 export default CategoriesController;

--- a/server/routes/categoriesRoute.js
+++ b/server/routes/categoriesRoute.js
@@ -5,5 +5,6 @@ const categoriesRouter = Router();
 
 categoriesRouter.get('/categories', CategoriesController.getAll);
 categoriesRouter.get('/categories/:category_id', CategoriesController.getOne);
+categoriesRouter.post('/categories', CategoriesController.addNew);
 
 export default categoriesRouter;


### PR DESCRIPTION
ensure new category of books can be added to the library database
ensure the post method can be used to add new category to the library

add logic to handle adding of new categories
add the HTTP post method to serve post requests

can be manually tested using postman, send a post request to 
`http://localhost:5001/api/v1/categories`

[Delivers [ft-feature-endpoint-categories-addNew](https://trello.com/c/p1ssfZsv/21-add-new-category-to-the-library-database)]