### PR TITLE
update books categories

### DIFF
--- a/server/controllers/categoriesController.js
+++ b/server/controllers/categoriesController.js
@@ -105,6 +105,36 @@ class CategoriesController {
         });
       });
   }
+
+  static update(req, res) {
+    const { category_name } = req.body;
+    if (!category_name) {
+      return res.status(400).json({
+        message: 'missing fields not allowed',
+      });
+    }
+    const id = parseInt(req.params.category_id, 10);
+    const query = `UPDATE book_library.categories SET category_name = '${category_name}' WHERE category_id = ${id} RETURNING *`;
+    dbConfig.query(query)
+      .then((categoryName) => {
+        if (categoryName.rowCount > 0) {
+          res.status(200).json({
+            status: true,
+            message: 'category successfully updated',
+            data: categoryName.rows,
+          });
+        } else {
+          res.status(400).json({
+            status: 'error',
+            message: 'category could not be updated',
+          });
+        }
+      })
+      .catch(err => res.status(404).json({
+        status: 'error',
+        message: err.message,
+      }));
+  }
 }
 
 export default CategoriesController;

--- a/server/routes/categoriesRoute.js
+++ b/server/routes/categoriesRoute.js
@@ -7,4 +7,5 @@ categoriesRouter.get('/categories', CategoriesController.getAll);
 categoriesRouter.get('/categories/:category_id', CategoriesController.getOne);
 categoriesRouter.post('/categories', CategoriesController.addNew);
 categoriesRouter.delete('/categories/:category_id', CategoriesController.delete);
+categoriesRouter.put('/categories/:category_id', CategoriesController.update);
 export default categoriesRouter;


### PR DESCRIPTION
ensure a given category can be updated
ensure the PUT request can be used to update categories

add the logic to handle updating of categories
add the PUT method to serve updating requests

can be manually tested using postman, send PUT request to 
`http://localhost:5001/api/v1/categories/category_id`

[Delivers[ ft-feature-endpoint-categories-update](https://trello.com/c/VeB9oum3/25-edit-and-update-a-book-category)]